### PR TITLE
Adds ability to download search results as csv.

### DIFF
--- a/app/controllers/csv_controller.rb
+++ b/app/controllers/csv_controller.rb
@@ -1,0 +1,30 @@
+require 'csv'
+
+class CsvController < CatalogController
+
+  configure_blacklight do |config|
+    config.default_solr_params[:rows] = 1000000
+  end
+
+  def index
+    (@response, @document_list) = get_search_results
+    send_data render_search_results_as_csv, filename: "#{csv_file_name}.csv"
+
+  end
+
+  def csv_file_name
+    "#{params.fetch(:q,"no-query")}#{params.fetch(:f,{}).keys.join("-")}"
+  end
+
+  def render_search_results_as_csv
+    show_fields = blacklight_config.show_fields.map {|solr_name, show_field| {:solr_name => solr_name, :label => show_field.label } }
+
+    csv_result = CSV.generate(headers: true) do |csv|
+      csv << show_fields.map { |field| field[:label] }
+
+      @document_list.each do |doc|
+        csv << show_fields.map { |field| doc.fetch(field[:solr_name], nil).to_a.join(" ; ") }
+      end
+    end
+  end
+end

--- a/app/views/catalog/_export_as.html.erb
+++ b/app/views/catalog/_export_as.html.erb
@@ -1,0 +1,7 @@
+<span class="sr-only"> Export as CSV </span>
+<div id="per_page-dropdown" class="btn-group">
+  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Export as <span class="caret"></span></button>
+  <ul class="dropdown-menu" role="menu">
+        <li><%= link_to('csv', csv_path(params)) %></li>
+  </ul>
+</div>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,0 +1,10 @@
+
+<div id="sortAndPerPage" class="clearfix">
+  <%= render :partial => "paginate_compact", :object => @response %>
+  <div class="search-widgets pull-right">
+    <%= render :partial => 'sort_widget' %>
+    <%= render :partial => 'per_page_widget' %>
+    <%= render :partial => 'view_type_group' %>
+    <%= render :partial => 'export_as' %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
 
 
   root :to => "catalog#index"
+
+  get 'csv' => "csv#index"
   
   post "harvest_all_providers"=>"application#harvest_all_providers"
   post "dump_whole_index"=>"application#dump_whole_index"


### PR DESCRIPTION
Creates csv_controller that subclasses catalog controller so we can alter number of results returned and overrides respond_to behavior.

Fixes #69.

There are a few ways to do this. The other option was to override the index method in `catalog_controller` to add a entry for csv in the `respond_to` section, but that would need to include the logic for looping through all results pages in the `render_search_results_as_csv` method in order to get all the results, not just that single page of results.

That might be an avenue to explore, but wanted to ship this.