### PR TITLE
Add setup script to quickly setup a local devlopment environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Execute the remaining tasks from the Hydra head application directory:
 cd dplah
 ```
 
+Then run the Setup script to quickly get your environemnt running
+```bash
+./setup.sh # you may need to `chmod +x` the setup file first"
+```
+
+The full details of configuring the application can be see below in the [Configuration](#configuration) section.
+
 ##Configuration
 
 To use this head, create a file under "`config/dpla.yml`" (you may copy the example file, "`config/dpla.yml.example`" and add the following:

--- a/config/dpla.yml.example
+++ b/config/dpla.yml.example
@@ -1,5 +1,5 @@
-harvest_data_directory: "/path/to/metadata/from/contributors"
-converted_foxml_directory: "/path/to/foxml/converted/metadata"
+harvest_data_directory: "tmp/harvest"
+converted_foxml_directory: "tmp/converted"
 pid_prefix: "changeme"
 partner: "Name of hub"
 human_log_path: '/abs/path/to/log/files'

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,23 @@
+
+# Make sure external requirements are present
+command -v redis-server >/dev/null 2>&1 || { echo >&2 "Redis server should be installed  Aborting."; exit 1; }
+
+command -v xsltproc >/dev/null 2>&1 || { echo >&2 "xsltproc should be available at the command line, but it's not installed.  Aborting."; exit 1; }
+
+# copy config files into place
+
+cp config/dpla.yml.example config/dpla.yml
+
+bundle install
+
+bundle exec rake db:migrate
+bundle exec rails g hydra:jetty
+bundle exec rake jetty:config
+
+bundle exec rake jetty:start
+
+sleep 10
+
+rails server -d 
+
+resque-pool --daemon 

--- a/setup.sh
+++ b/setup.sh
@@ -20,4 +20,4 @@ sleep 10
 
 rails server -d 
 
-resque-pool --daemon 
+RAILS_ENV=development resque-pool --daemon 


### PR DESCRIPTION
Add a bash script that runs through the steps required to get a basic development environment running.