### PR TITLE
Ensure uri's conform to URI spec

### DIFF
--- a/lib/harvest_utils.rb
+++ b/lib/harvest_utils.rb
@@ -189,6 +189,7 @@ module HarvestUtils
       normalize_dates(doc, "//date")
       normalize_language(doc, "//language")
       normalize_rights(doc, "//dc:rights")
+      normalize_rights(doc, "//rights")
 
       standardize_formats(doc, "//dc:format")
       normalize_dates(doc, "//dc:date")
@@ -437,10 +438,15 @@ module HarvestUtils
       node_update = doc.search(string_to_search, "dc" => "http://purl.org/dc/elements/1.1/")
       node_update.each do |node_value|
         if node_value.inner_html.downcase.starts_with?("http")
-          node_value.inner_html = node_value.inner_html.downcase
+          conform_url node_value
         end
       end
     end
+
+    def self.conform_url(url_string)
+      URI(url_string).to_s
+    end
+
 
     def self.normalize_first_case(value)
       value.downcase

--- a/lib/harvest_utils.rb
+++ b/lib/harvest_utils.rb
@@ -438,7 +438,7 @@ module HarvestUtils
       node_update = doc.search(string_to_search, "dc" => "http://purl.org/dc/elements/1.1/")
       node_update.each do |node_value|
         if node_value.inner_html.downcase.starts_with?("http")
-          conform_url node_value
+          node_value.inner_html = conform_url node_value
         end
       end
     end

--- a/spec/lib/harvest_utils_spec.rb
+++ b/spec/lib/harvest_utils_spec.rb
@@ -174,10 +174,6 @@ RSpec.describe HarvestUtils do
       FileUtils.rm Dir.glob "#{convert_directory}/*.xml"
     end
 
-    it 'something' do
-
-    end
-
     xit "expect valid XML" do
       HarvestUtils::cleanup(provider_small_collection)
       Dir.glob(File.join(convert_directory, '**', '*.xml')).each do |file|

--- a/spec/lib/harvest_utils_spec.rb
+++ b/spec/lib/harvest_utils_spec.rb
@@ -174,6 +174,10 @@ RSpec.describe HarvestUtils do
       FileUtils.rm Dir.glob "#{convert_directory}/*.xml"
     end
 
+    it 'something' do
+
+    end
+
     xit "expect valid XML" do
       HarvestUtils::cleanup(provider_small_collection)
       Dir.glob(File.join(convert_directory, '**', '*.xml')).each do |file|
@@ -354,6 +358,20 @@ RSpec.describe HarvestUtils do
       expect(lambda{HarvestUtils::remove_selective(provider_small_collection, "")}).to raise_error SystemExit
       expect(ActiveFedora::Base.count).to eq(@initial_count)
       expect(ActiveFedora::Base.count).to_not eq(0)
+    end
+
+  end
+
+  describe '#conform_urls' do
+    let(:uppercase_url) {"HTTP://EXAMPLE.COM/SOMEOTHERTHING"}
+    let(:rightsstatement) {"http://rightsstatements.org/vocab/InC-RUU/1.0/"}
+
+    it 'ensure http urls start with lower case protocol' do
+      expect(HarvestUtils::conform_url(uppercase_url)).to start_with 'http'
+    end
+
+    it "doesn't alter url path" do
+      expect(HarvestUtils::conform_url(rightsstatement)).to include "/vocab/InC-RUU/1.0/"
     end
 
   end


### PR DESCRIPTION
Make sure URIs start with lower case protocol, but do not alter case of URI path.

Also ensures that same operations are performed on data for UI and for outbound OAI feed.

Relates to #141