### PR TITLE
Bepress identifier fixes

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -2,7 +2,7 @@ module BlacklightHelper
 	 include Blacklight::BlacklightHelperBehavior
 	 def render_default_thumbnail_link(document, options = {})
 		 track_url = "#{url_for(url_for_document(document))}/track?counter=#{options[:counter]}&search_id=#{current_search_session.try(:id)}"
-		 default_thumb = link_to(image_tag("default-thumbnail.png", :alt => document['title_tesim'].to_sentence), url_for_document(document), :'data-context-href' => track_url)
+		 default_thumb = document['title_tesim'].present? ? link_to(image_tag("default-thumbnail.png", :alt => document['title_tesim'].to_sentence), url_for_document(document), :'data-context-href' => track_url) : nil
 		 return default_thumb
 	 end
 end

--- a/app/models/oai_rec.rb
+++ b/app/models/oai_rec.rb
@@ -137,12 +137,11 @@ class OaiRec < ActiveFedora::Base
 		end
 	end
 
-	def remove_fake_identifiers_oaidc(passthrough_url)
-		g = self.identifier.select {|b| b.include?(passthrough_url)}
-		h = "<dc:identifier>#{g[0]}</dc:identifier>"
-		self.DC.content=self.DC.content.gsub(h,"")
+	def remove_identifier(search_on_string)
+		dc_content = self.DC.content.split("\n")
+		self.DC.content = dc_content.delete_if{|a| a.include?(search_on_string)}.join("\n")
+		self.identifier = self.identifier.delete_if{|a| a.include?(search_on_string)}
 		self.save
-		self.identifier = self.identifier.delete_if{|a| a.include?(passthrough_url)}
 	end
 
 	def assign_rights

--- a/lib/harvest_utils.rb
+++ b/lib/harvest_utils.rb
@@ -623,9 +623,9 @@ module HarvestUtils
     end
 
     def self.remove_unwanted_identifiers(obj, provider)
-      obj.remove_identifier(provider, @passthrough_url) if provider.common_repository_type == 'Passthrough Workflow'
-      obj.remove_identifier(provider, 'viewcontent.cgi?') if provider.common_repository_type == 'Bepress'
-      obj.remove_identifier(provider, '/videos/') if provider.common_repository_type == 'Bepress'
+      obj.remove_identifier(@passthrough_url) if provider.common_repository_type == 'Passthrough Workflow'
+      obj.remove_identifier('viewcontent.cgi?') if provider.common_repository_type == 'Bepress'
+      obj.remove_identifier('/videos/') if provider.common_repository_type == 'Bepress'
     end
 
     ###

--- a/lib/harvest_utils.rb
+++ b/lib/harvest_utils.rb
@@ -248,7 +248,7 @@ module HarvestUtils
       obj.assign_contributing_institution
       obj.add_dcmi_terms_to_type(provider)
       build_identifier(obj, provider) unless provider.identifier_pattern.blank? || provider.identifier_pattern.empty?
-      obj.remove_fake_identifiers_oaidc(@passthrough_url)
+      remove_unwanted_identifiers(obj, provider)
       obj.reorg_identifiers
       obj.add_identifier(thumbnail) unless provider.common_repository_type == "Passthrough Workflow" || thumbnail.nil?
       obj.clean_iso8601_date_field
@@ -614,7 +614,6 @@ module HarvestUtils
 
     def self.has_noharvest_stopword?(record)
       record.metadata.to_s.include? @noharvest_stopword
-
     end
 
     def self.build_identifier(obj, provider)
@@ -623,12 +622,19 @@ module HarvestUtils
       obj.add_identifier(assembled_identifier)
     end
 
+    def self.remove_unwanted_identifiers(obj, provider)
+      obj.remove_identifier(provider, @passthrough_url) if provider.common_repository_type == 'Passthrough Workflow'
+      obj.remove_identifier(provider, 'viewcontent.cgi?') if provider.common_repository_type == 'Bepress'
+      obj.remove_identifier(provider, '/videos/') if provider.common_repository_type == 'Bepress'
+    end
+
     ###
     # special case customizations -- hopefully can be eliminated later
     ###
     def self.custom_file_prefixing(file_prefix, provider)
       # little fix for weird nested OAI identifiers in Bepress
       file_prefix.slice!("publication_") if provider.common_repository_type == "Bepress"
+
 
       # little fix for additional weirdness in Bepress for PCOM
       file_prefix.slice!("do_") if provider.common_repository_type == "Bepress" && provider.endpoint_url == "http://digitalcommons.pcom.edu/do/oai/" && provider.set == "publication:do_yearbooks"


### PR DESCRIPTION
Removes unwanted identifiers from Bepress instances with "video" and "viewcontent" patterns.