### PR TITLE
Tests for blank titles 

### DIFF
--- a/lib/harvest_utils.rb
+++ b/lib/harvest_utils.rb
@@ -237,7 +237,6 @@ module HarvestUtils
 
       begin
         unless has_required_fields(file)
-          binding.pry
           quarantine_and_report(file)
           next
         end

--- a/spec/fixtures/required_fields/no_identifier.xml
+++ b/spec/fixtures/required_fields/no_identifier.xml
@@ -1,21 +1,95 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<records>
-<manifest><partner>test-partner</partner><contributing_institution>Temple University</contributing_institution><intermediate_provider></intermediate_provider><set_spec>p16002coll2</set_spec><collection_name>SCRC Photographs</collection_name><common_repository_type></common_repository_type><endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url><provider_id_prefix>temple</provider_id_prefix><rights_statement></rights_statement><pid_prefix>test-prefix</pid_prefix><harvest_data_directory>tmp/test/harvest_data</harvest_data_directory><converted_foxml_directory>tmp/test/converted_foxml</converted_foxml_directory></manifest>
-<record><header><datestamp>2011-06-28</datestamp></header><metadata>
-<oai_dc:dc xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xsi:schemaLocation='http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
-<dc:title>View along Cecil B. Moore Avenue</dc:title>
-<dc:date>2011-04-14</dc:date>
-<dc:creator>Scheihing, Craig</dc:creator>
-<dc:subject>Streets; Storefronts; Business enterprises;</dc:subject>
-<dc:subject>Columbia Deli (Philadelphia, Pa.); 1634 Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:subject>
-<dc:coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
-<dc:coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
-<dc:description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
-<dc:format>image/jp2</dc:format>
-<dc:type>Photographs</dc:type>
-<dc:format>1 photograph, color; 4 x 6 in.</dc:format>
-<dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</dc:rights>
-<dc:relation>Urban Archives Photographs</dc:relation>
-<dc:relation>SCRC Photographs; Civil Rights in a Northern City; Columbia Avenue Riots;</dc:relation>
-</metadata></record>
-</records>
+
+
+<?xml version="1.0"?>
+<foxml:digitalObject xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" VERSION="1.1" PID="test-prefix:temple_p16002coll2_1" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="FOXML OAI-PMH"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2016-09-02T15:36:49-04:00"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
+</foxml:objectProperties>
+<foxml:datastream ID="partner" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="partner.0" LABEL="Partner supplied metadata" MIMETYPE="text/xml">
+    <foxml:xmlContent>
+        <fields>
+            <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">View along Cecil B. Moore Avenue</dc:title>
+        </fields>
+    </foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="DC.0" LABEL="Dublin Core Record for this object" CREATED="2013-11-06T21:24:13.236Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="342">
+    <foxml:xmlContent>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+        <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">View along Cecil B. Moore Avenue</dc:title>
+        <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Scheihing, Craig</dc:creator>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Streets</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Storefronts</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Business enterprises</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Columbia Deli (Philadelphia, Pa.)</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">1634 Cecil B. Moore Avenue (Philadelphia, Pa.)</dc:subject>
+        <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
+        <dc:contributor xmlns:dc="http://purl.org/dc/elements/1.1/">Temple University</dc:contributor>
+        <dc:date xmlns:dc="http://purl.org/dc/elements/1.1/">2011-04-14</dc:date>
+        <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">Photographs</dc:type>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">image/jp2</dc:format>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">1 photograph, color</dc:format>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">4 x 6 in.</dc:format>
+        <dc:source xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">SCRC Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Urban Archives Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">SCRC Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Civil Rights in a Northern City</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Columbia Avenue Riots</dc:relation>
+        <dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/">Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
+        <dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/">Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
+        <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/">This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</dc:rights>
+        <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+    </oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="descMetadata.0" LABEL="" CREATED="2013-02-25T16:43:06.315Z" MIMETYPE="text/xml" SIZE="414">
+    <foxml:xmlContent>
+        <fields>
+            <title>View along Cecil B. Moore Avenue</title>
+            <creator>Scheihing, Craig</creator>
+            <subject>Streets</subject>
+            <subject>Storefronts</subject>
+            <subject>Business enterprises</subject>
+            <subject>Columbia Deli (Philadelphia, Pa.)</subject>
+            <subject>1634 Cecil B. Moore Avenue (Philadelphia, Pa.)</subject>
+            <description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</description>
+            <date>2011-04-14</date>
+            <type>Photographs</type>
+            <format>image/jp2</format>
+            <format>1 photograph, color</format>
+            <format>4 x 6 in.</format>
+            <identifier>00130001</identifier>
+            <identifier>http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</identifier>
+            <source/>
+            <relation>Urban Archives Photographs</relation>
+            <relation>SCRC Photographs</relation>
+            <relation>Civil Rights in a Northern City</relation>
+            <relation>Columbia Avenue Riots</relation>
+            <coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</coverage>
+            <coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</coverage>
+            <rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</rights>
+            <contributing_institution>Temple University</contributing_institution>
+            <intermediate_provider/>
+            <set_spec>p16002coll2</set_spec>
+            <collection_name>SCRC Photographs</collection_name>
+            <partner>test-partner</partner>
+            <common_repository_type/>
+            <endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url>
+            <provider_id_prefix>temple</provider_id_prefix>
+            <identifier_pattern/>
+            <identifier_token/>
+            <rights/>
+        </fields>
+    </foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/spec/fixtures/required_fields/no_identifier.xml
+++ b/spec/fixtures/required_fields/no_identifier.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<records>
+<manifest><partner>test-partner</partner><contributing_institution>Temple University</contributing_institution><intermediate_provider></intermediate_provider><set_spec>p16002coll2</set_spec><collection_name>SCRC Photographs</collection_name><common_repository_type></common_repository_type><endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url><provider_id_prefix>temple</provider_id_prefix><rights_statement></rights_statement><pid_prefix>test-prefix</pid_prefix><harvest_data_directory>tmp/test/harvest_data</harvest_data_directory><converted_foxml_directory>tmp/test/converted_foxml</converted_foxml_directory></manifest>
+<record><header><datestamp>2011-06-28</datestamp></header><metadata>
+<oai_dc:dc xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xsi:schemaLocation='http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+<dc:title>View along Cecil B. Moore Avenue</dc:title>
+<dc:date>2011-04-14</dc:date>
+<dc:creator>Scheihing, Craig</dc:creator>
+<dc:subject>Streets; Storefronts; Business enterprises;</dc:subject>
+<dc:subject>Columbia Deli (Philadelphia, Pa.); 1634 Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:subject>
+<dc:coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
+<dc:coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
+<dc:description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
+<dc:format>image/jp2</dc:format>
+<dc:type>Photographs</dc:type>
+<dc:format>1 photograph, color; 4 x 6 in.</dc:format>
+<dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</dc:rights>
+<dc:relation>Urban Archives Photographs</dc:relation>
+<dc:relation>SCRC Photographs; Civil Rights in a Northern City; Columbia Avenue Riots;</dc:relation>
+</metadata></record>
+</records>

--- a/spec/fixtures/required_fields/no_rights.xml
+++ b/spec/fixtures/required_fields/no_rights.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<records>
+<manifest><partner>test-partner</partner><contributing_institution>Temple University</contributing_institution><intermediate_provider></intermediate_provider><set_spec>p16002coll2</set_spec><collection_name>SCRC Photographs</collection_name><common_repository_type></common_repository_type><endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url><provider_id_prefix>temple</provider_id_prefix><rights_statement></rights_statement><pid_prefix>test-prefix</pid_prefix><harvest_data_directory>tmp/test/harvest_data</harvest_data_directory><converted_foxml_directory>tmp/test/converted_foxml</converted_foxml_directory></manifest>
+<record><header><identifier>p16002coll2_1</identifier><datestamp>2011-06-28</datestamp></header><metadata>
+<oai_dc:dc xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xsi:schemaLocation='http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+<dc:title>View along Cecil B. Moore Avenue</dc:title>
+<dc:date>2011-04-14</dc:date>
+<dc:creator>Scheihing, Craig</dc:creator>
+<dc:subject>Streets; Storefronts; Business enterprises;</dc:subject>
+<dc:subject>Columbia Deli (Philadelphia, Pa.); 1634 Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:subject>
+<dc:coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
+<dc:coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
+<dc:description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
+<dc:format>image/jp2</dc:format>
+<dc:type>Photographs</dc:type>
+<dc:format>1 photograph, color; 4 x 6 in.</dc:format>
+<dc:relation>Urban Archives Photographs</dc:relation>
+<dc:relation>SCRC Photographs; Civil Rights in a Northern City; Columbia Avenue Riots;</dc:relation>
+<dc:identifier>00130001</dc:identifier>
+<dc:identifier>http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</dc:identifier></oai_dc:dc>
+</metadata></record>
+</records>

--- a/spec/fixtures/required_fields/no_rights.xml
+++ b/spec/fixtures/required_fields/no_rights.xml
@@ -1,22 +1,95 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<records>
-<manifest><partner>test-partner</partner><contributing_institution>Temple University</contributing_institution><intermediate_provider></intermediate_provider><set_spec>p16002coll2</set_spec><collection_name>SCRC Photographs</collection_name><common_repository_type></common_repository_type><endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url><provider_id_prefix>temple</provider_id_prefix><rights_statement></rights_statement><pid_prefix>test-prefix</pid_prefix><harvest_data_directory>tmp/test/harvest_data</harvest_data_directory><converted_foxml_directory>tmp/test/converted_foxml</converted_foxml_directory></manifest>
-<record><header><identifier>p16002coll2_1</identifier><datestamp>2011-06-28</datestamp></header><metadata>
-<oai_dc:dc xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xsi:schemaLocation='http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
-<dc:title>View along Cecil B. Moore Avenue</dc:title>
-<dc:date>2011-04-14</dc:date>
-<dc:creator>Scheihing, Craig</dc:creator>
-<dc:subject>Streets; Storefronts; Business enterprises;</dc:subject>
-<dc:subject>Columbia Deli (Philadelphia, Pa.); 1634 Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:subject>
-<dc:coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
-<dc:coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
-<dc:description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
-<dc:format>image/jp2</dc:format>
-<dc:type>Photographs</dc:type>
-<dc:format>1 photograph, color; 4 x 6 in.</dc:format>
-<dc:relation>Urban Archives Photographs</dc:relation>
-<dc:relation>SCRC Photographs; Civil Rights in a Northern City; Columbia Avenue Riots;</dc:relation>
-<dc:identifier>00130001</dc:identifier>
-<dc:identifier>http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</dc:identifier></oai_dc:dc>
-</metadata></record>
-</records>
+
+
+<?xml version="1.0"?>
+<foxml:digitalObject xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" VERSION="1.1" PID="test-prefix:temple_p16002coll2_1" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="FOXML OAI-PMH"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2016-09-02T15:36:49-04:00"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
+</foxml:objectProperties>
+<foxml:datastream ID="partner" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="partner.0" LABEL="Partner supplied metadata" MIMETYPE="text/xml">
+    <foxml:xmlContent>
+        <fields>
+            <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">View along Cecil B. Moore Avenue</dc:title>
+        </fields>
+    </foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="DC.0" LABEL="Dublin Core Record for this object" CREATED="2013-11-06T21:24:13.236Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="342">
+    <foxml:xmlContent>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+        <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">View along Cecil B. Moore Avenue</dc:title>
+        <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Scheihing, Craig</dc:creator>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Streets</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Storefronts</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Business enterprises</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Columbia Deli (Philadelphia, Pa.)</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">1634 Cecil B. Moore Avenue (Philadelphia, Pa.)</dc:subject>
+        <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
+        <dc:contributor xmlns:dc="http://purl.org/dc/elements/1.1/">Temple University</dc:contributor>
+        <dc:date xmlns:dc="http://purl.org/dc/elements/1.1/">2011-04-14</dc:date>
+        <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">Photographs</dc:type>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">image/jp2</dc:format>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">1 photograph, color</dc:format>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">4 x 6 in.</dc:format>
+        <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">00130001</dc:identifier>
+        <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</dc:identifier>
+        <dc:source xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">SCRC Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Urban Archives Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">SCRC Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Civil Rights in a Northern City</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Columbia Avenue Riots</dc:relation>
+        <dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/">Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
+        <dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/">Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
+      </oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="descMetadata.0" LABEL="" CREATED="2013-02-25T16:43:06.315Z" MIMETYPE="text/xml" SIZE="414">
+    <foxml:xmlContent>
+        <fields>
+            <title>View along Cecil B. Moore Avenue</title>
+            <creator>Scheihing, Craig</creator>
+            <subject>Streets</subject>
+            <subject>Storefronts</subject>
+            <subject>Business enterprises</subject>
+            <subject>Columbia Deli (Philadelphia, Pa.)</subject>
+            <subject>1634 Cecil B. Moore Avenue (Philadelphia, Pa.)</subject>
+            <description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</description>
+            <date>2011-04-14</date>
+            <type>Photographs</type>
+            <format>image/jp2</format>
+            <format>1 photograph, color</format>
+            <format>4 x 6 in.</format>
+            <identifier>00130001</identifier>
+            <identifier>http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</identifier>
+            <source/>
+            <relation>Urban Archives Photographs</relation>
+            <relation>SCRC Photographs</relation>
+            <relation>Civil Rights in a Northern City</relation>
+            <relation>Columbia Avenue Riots</relation>
+            <coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</coverage>
+            <coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</coverage>
+            <rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</rights>
+            <contributing_institution>Temple University</contributing_institution>
+            <intermediate_provider/>
+            <set_spec>p16002coll2</set_spec>
+            <collection_name>SCRC Photographs</collection_name>
+            <partner>test-partner</partner>
+            <common_repository_type/>
+            <endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url>
+            <provider_id_prefix>temple</provider_id_prefix>
+            <identifier_pattern/>
+            <identifier_token/>
+            <rights/>
+        </fields>
+    </foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/spec/fixtures/required_fields/no_title.xml
+++ b/spec/fixtures/required_fields/no_title.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<records>
+<manifest><partner>test-partner</partner><contributing_institution>Temple University</contributing_institution><intermediate_provider></intermediate_provider><set_spec>p16002coll2</set_spec><collection_name>SCRC Photographs</collection_name><common_repository_type></common_repository_type><endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url><provider_id_prefix>temple</provider_id_prefix><rights_statement></rights_statement><pid_prefix>test-prefix</pid_prefix><harvest_data_directory>tmp/test/harvest_data</harvest_data_directory><converted_foxml_directory>tmp/test/converted_foxml</converted_foxml_directory></manifest>
+<record><header><identifier>p16002coll2_1</identifier><datestamp>2011-06-28</datestamp></header><metadata>
+<oai_dc:dc xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xsi:schemaLocation='http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+<dc:date>2011-04-14</dc:date>
+<dc:creator>Scheihing, Craig</dc:creator>
+<dc:subject>Streets; Storefronts; Business enterprises;</dc:subject>
+<dc:subject>Columbia Deli (Philadelphia, Pa.); 1634 Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:subject>
+<dc:coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
+<dc:coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
+<dc:description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
+<dc:format>image/jp2</dc:format>
+<dc:type>Photographs</dc:type>
+<dc:format>1 photograph, color; 4 x 6 in.</dc:format>
+<dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</dc:rights>
+<dc:relation>Urban Archives Photographs</dc:relation>
+<dc:relation>SCRC Photographs; Civil Rights in a Northern City; Columbia Avenue Riots;</dc:relation>
+<dc:identifier>00130001</dc:identifier>
+<dc:identifier>http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</dc:identifier></oai_dc:dc>
+</metadata></record>
+</records>

--- a/spec/fixtures/required_fields/no_title.xml
+++ b/spec/fixtures/required_fields/no_title.xml
@@ -1,22 +1,96 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<records>
-<manifest><partner>test-partner</partner><contributing_institution>Temple University</contributing_institution><intermediate_provider></intermediate_provider><set_spec>p16002coll2</set_spec><collection_name>SCRC Photographs</collection_name><common_repository_type></common_repository_type><endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url><provider_id_prefix>temple</provider_id_prefix><rights_statement></rights_statement><pid_prefix>test-prefix</pid_prefix><harvest_data_directory>tmp/test/harvest_data</harvest_data_directory><converted_foxml_directory>tmp/test/converted_foxml</converted_foxml_directory></manifest>
-<record><header><identifier>p16002coll2_1</identifier><datestamp>2011-06-28</datestamp></header><metadata>
-<oai_dc:dc xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/' xsi:schemaLocation='http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
-<dc:date>2011-04-14</dc:date>
-<dc:creator>Scheihing, Craig</dc:creator>
-<dc:subject>Streets; Storefronts; Business enterprises;</dc:subject>
-<dc:subject>Columbia Deli (Philadelphia, Pa.); 1634 Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:subject>
-<dc:coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
-<dc:coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
-<dc:description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
-<dc:format>image/jp2</dc:format>
-<dc:type>Photographs</dc:type>
-<dc:format>1 photograph, color; 4 x 6 in.</dc:format>
-<dc:rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</dc:rights>
-<dc:relation>Urban Archives Photographs</dc:relation>
-<dc:relation>SCRC Photographs; Civil Rights in a Northern City; Columbia Avenue Riots;</dc:relation>
-<dc:identifier>00130001</dc:identifier>
-<dc:identifier>http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</dc:identifier></oai_dc:dc>
-</metadata></record>
-</records>
+
+
+<?xml version="1.0"?>
+<foxml:digitalObject xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" VERSION="1.1" PID="test-prefix:temple_p16002coll2_1" xsi:schemaLocation="info:fedora/fedora-system:def/foxml# http://www.fedora.info/definitions/1/0/foxml1-1.xsd">
+<foxml:objectProperties>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#state" VALUE="Active"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#label" VALUE="FOXML OAI-PMH"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#ownerId" VALUE=""/>
+    <foxml:property NAME="info:fedora/fedora-system:def/model#createdDate" VALUE="2016-09-02T15:36:49-04:00"/>
+    <foxml:property NAME="info:fedora/fedora-system:def/view#lastModifiedDate" VALUE=""/>
+</foxml:objectProperties>
+<foxml:datastream ID="partner" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="partner.0" LABEL="Partner supplied metadata" MIMETYPE="text/xml">
+    <foxml:xmlContent>
+        <fields>
+            <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">View along Cecil B. Moore Avenue</dc:title>
+        </fields>
+    </foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="DC" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="DC.0" LABEL="Dublin Core Record for this object" CREATED="2013-11-06T21:24:13.236Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="342">
+    <foxml:xmlContent>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+        <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Scheihing, Craig</dc:creator>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Streets</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Storefronts</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Business enterprises</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">Columbia Deli (Philadelphia, Pa.)</dc:subject>
+        <dc:subject xmlns:dc="http://purl.org/dc/elements/1.1/">1634 Cecil B. Moore Avenue (Philadelphia, Pa.)</dc:subject>
+        <dc:description xmlns:dc="http://purl.org/dc/elements/1.1/">View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</dc:description>
+        <dc:contributor xmlns:dc="http://purl.org/dc/elements/1.1/">Temple University</dc:contributor>
+        <dc:date xmlns:dc="http://purl.org/dc/elements/1.1/">2011-04-14</dc:date>
+        <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">Photographs</dc:type>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">image/jp2</dc:format>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">1 photograph, color</dc:format>
+        <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">4 x 6 in.</dc:format>
+        <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">00130001</dc:identifier>
+        <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</dc:identifier>
+        <dc:source xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">SCRC Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Urban Archives Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">SCRC Photographs</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Civil Rights in a Northern City</dc:relation>
+        <dc:relation xmlns:dc="http://purl.org/dc/elements/1.1/">Columbia Avenue Riots</dc:relation>
+        <dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/">Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</dc:coverage>
+        <dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/">Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</dc:coverage>
+        <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/">This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</dc:rights>
+        <dc:rights xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+    </oai_dc:dc>
+</foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+<foxml:datastream ID="descMetadata" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
+    <foxml:datastreamVersion ID="descMetadata.0" LABEL="" CREATED="2013-02-25T16:43:06.315Z" MIMETYPE="text/xml" SIZE="414">
+    <foxml:xmlContent>
+        <fields>
+            <title>View along Cecil B. Moore Avenue</title>
+            <creator>Scheihing, Craig</creator>
+            <subject>Streets</subject>
+            <subject>Storefronts</subject>
+            <subject>Business enterprises</subject>
+            <subject>Columbia Deli (Philadelphia, Pa.)</subject>
+            <subject>1634 Cecil B. Moore Avenue (Philadelphia, Pa.)</subject>
+            <description>View of the Columbia Deli and other storefronts near 17th Street and Cecil B. Moore (formerly Columbia) Avenue.</description>
+            <date>2011-04-14</date>
+            <type>Photographs</type>
+            <format>image/jp2</format>
+            <format>1 photograph, color</format>
+            <format>4 x 6 in.</format>
+            <identifier>00130001</identifier>
+            <identifier>http://cdm16002.contentdm.oclc.org/cdm/ref/collection/p16002coll2/id/1</identifier>
+            <source/>
+            <relation>Urban Archives Photographs</relation>
+            <relation>SCRC Photographs</relation>
+            <relation>Civil Rights in a Northern City</relation>
+            <relation>Columbia Avenue Riots</relation>
+            <coverage>Seventeenth Street and Cecil B. Moore Avenue (Philadelphia, Pa.); Seventeenth Street and Columbia Avenue (Philadlephia, Pa.);</coverage>
+            <coverage>Philadelphia (Pa.); Columbia Avenue (Philadelphia, Pa.); Cecil B. Moore Avenue (Philadelphia, Pa.);</coverage>
+            <rights>This material is subject to copyright law and is made available for private study, scholarship, and research purposes only. For access to the original or a high resolution reproduction, and for permission to publish, please contact Temple University Libraries, Special Collections Research Center, scrc@temple.edu, 215-204-8257.</rights>
+            <contributing_institution>Temple University</contributing_institution>
+            <intermediate_provider/>
+            <set_spec>p16002coll2</set_spec>
+            <collection_name>SCRC Photographs</collection_name>
+            <partner>test-partner</partner>
+            <common_repository_type/>
+            <endpoint_url>http://cdm16002.contentdm.oclc.org/oai/oai.php</endpoint_url>
+            <provider_id_prefix>temple</provider_id_prefix>
+            <identifier_pattern/>
+            <identifier_token/>
+            <rights/>
+        </fields>
+    </foxml:xmlContent>
+</foxml:datastreamVersion>
+</foxml:datastream>
+</foxml:digitalObject>

--- a/spec/lib/harvest_utils_spec.rb
+++ b/spec/lib/harvest_utils_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe HarvestUtils do
 
       # Simulate data harvest
       FileUtils.cp_r File.join(convert_fixtures_directory, "ingest", "."), convert_directory
-      
+
       # Create the harvest log file
       HarvestUtils::create_log_file(log_name)
     end
@@ -369,6 +369,20 @@ RSpec.describe HarvestUtils do
     it "doesn't alter url path" do
       expect(HarvestUtils::conform_url(rightsstatement)).to include "/vocab/InC-RUU/1.0/"
     end
+
+  end
+
+  describe '#has_required_fields' do
+    context 'when the file has no dc:title field' do
+      let(:file) { File.join(RSpec.configuration.fixture_path,'required_fields','no_title.xml')}
+
+      it 'returns false' do
+        expect(HarvestUtils::has_required_fields(file)).to be false
+      end
+
+    end
+
+
 
   end
 

--- a/spec/lib/harvest_utils_spec.rb
+++ b/spec/lib/harvest_utils_spec.rb
@@ -382,6 +382,24 @@ RSpec.describe HarvestUtils do
 
     end
 
+    context 'when the file has no dc:rights field' do
+      let(:file) { File.join(RSpec.configuration.fixture_path,'required_fields','no_rights.xml')}
+
+      it 'returns false' do
+        expect(HarvestUtils::has_required_fields(file)).to be false
+      end
+
+    end
+
+    context 'when the file has no dc:identifier field' do
+      let(:file) { File.join(RSpec.configuration.fixture_path,'required_fields','no_identifier.xml')}
+
+      it 'returns false' do
+        expect(HarvestUtils::has_required_fields(file)).to be false
+      end
+
+    end
+
 
 
   end


### PR DESCRIPTION
Not to be merged - just creating so the Travis runs.

@kelynch I would expect [these three tests](https://github.com/tulibraries/dplah/compare/test-blank-title?expand=1#diff-08c2f4955b16154c7f9c6a4e9e89f895R375) to pass, but [only identifier passes](https://travis-ci.org/tulibraries/dplah/jobs/255674531#L993) because as the [last item in the list](https://github.com/tulibraries/dplah/compare/test-blank-title?w=1&expand=1#diff-79897135fb8ee79b7a1aad790224aebaR651), if identifier is present, it sets the previously set false back to true?

Am I misunderstanding the use case? 