### PR TITLE
Updates to address new Internet Archive thumbnail patterns

### DIFF
--- a/lib/thumbnail_utils.rb
+++ b/lib/thumbnail_utils.rb
@@ -131,7 +131,7 @@ module ThumbnailUtils
     thumbnail = ""
     f = obj.identifier
     f.each do |thumb|
-      if thumb.start_with?('http') && thumb.end_with?(*(OaiRec.thumbnail_extensions))
+      if thumb.start_with?('http') && (thumb.end_with?(*(OaiRec.thumbnail_extensions)) || thumb.include?('archive.org/services/img'))
         thumbnail = thumb
       end
     end


### PR DESCRIPTION
Addresses #199 

Note this only fails because of file extension checks, accepting only thumbnails that end in certain image file extensions.  This was originally done as the initial Omeka-based passthrough regarded exposed files as thumbnails, which was later changed to last-position identifiers coming from passthrough should be regarded as thumbnails.  Currently, this will address thumbnails in that position coming from IA and/or ending with an image file extension, but any new thumbnails coming from passthrough workflow not meeting these conditions (despite potentially being valid thumbnails) will continue to fail.

To address this more broadly, I'd like to modify the code to do a check on position rather than content of the identifier field.  Thoughts/concerns on this?

EDIT: On second thought, while this check is still somewhat brittle, I'm less in favor of the check-on-position fix now, as it would become very difficult to deal with passthrough workflow seeds that don't have thumbnails.  For the time being, this fix as it exists now addresses thumbnails beginning with thumbnail extensions (jpg, gif, png), and any IA thumbnails coming from the new HTTPS URL pattern.  However, I leave it to the other devs to decide whether this approach is best.  I'm totally open to suggestion.